### PR TITLE
use streams, dependent tasks for gulp task ordering

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,17 +4,26 @@ var babel = require('gulp-babel');
 var sass = require('gulp-sass');
 var autoprefixer = require('gulp-autoprefixer');
 var rename = require('gulp-rename');
+var concat = require('gulp-concat');
 var del = require('del');
-var watch = require('gulp-watch');
 
 var sourceFiles = {
-  allHtml:  './src/**/*.html',
-  allJs:    './src/**/*.js',
-  allScss:  './src/**/*.scss'
+  allHtml:  'src/**/*.html',
+  allJs:    'src/**/*.js',
+  allScss:  'src/**/*.scss'
 };
 
-gulp.task('default', ['clean'], function() {
-  return gulp.start('serve', 'watch', 'reload', 'scss', 'html', 'js');
+gulp.task('default', ['build', 'watch', 'serve']);
+
+gulp.task('build', ['clean'], function() {
+  gulp.start(['js', 'scss', 'html']);
+});
+
+gulp.task('watch', function() {
+  gulp.watch(sourceFiles.allHtml, ['html']);
+  gulp.watch(sourceFiles.allJs, ['js']);
+  gulp.watch(sourceFiles.allScss, ['scss']);
+  gulp.watch('dist/**/*', ['reload']);
 });
 
 gulp.task('serve', function() {
@@ -25,48 +34,31 @@ gulp.task('serve', function() {
   });
 });
 
-gulp.task('watch', function() {
-  watch(sourceFiles.allHtml, function() {
-    gulp.start('html');
-  });
-  
-  watch(sourceFiles.allJs, function() {
-    gulp.start('js');
-  });
-  
-  watch(sourceFiles.allScss, function() {
-    gulp.start('scss');
-  });
-});
-
 gulp.task('reload', function() {
-  watch('./dist/**/*', function() {
-    gulp.src('./dist/**/*')
-      .pipe(connect.reload());
-  });
+  gulp.src('dist/**/*').pipe(connect.reload());
 });
 
 gulp.task('scss', function() {
-  return gulp.src('./src/css/main.scss')
+  return gulp.src('src/css/main.scss')
     .pipe(sass().on('error', sass.logError))
     .pipe(rename('main.css'))
     .pipe(autoprefixer({
       browsers: ['last 2 versions'],
       cascade: false
     }))
-    .pipe(gulp.dest('./dist/css'));
+    .pipe(gulp.dest('dist/css'));
 });
 
 gulp.task('html', function() {
   return gulp.src(sourceFiles.allHtml)
-    .pipe(gulp.dest('./dist'));
+    .pipe(gulp.dest('dist'));
 });
 
 gulp.task('js', function() {
   return gulp.src(sourceFiles.allJs)
     .pipe(babel())
-    .pipe(rename('app.js'))
-    .pipe(gulp.dest('./dist/js'));
+    .pipe(concat('app.js'))
+    .pipe(gulp.dest('dist/js'));
 });
 
 gulp.task('clean', function(cb) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gulp-gh-pages": "^0.5.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
-    "gulp-watch": "^4.3.5"
+    "del": "^2.0.2",
+    "gulp-concat": "^2.6.0"
   }
 }


### PR DESCRIPTION
A major issue here was the notion of tasks occuring serially vs. parallel. `gulp.start` is a parallel starter of tasks and they can run into each other. This PR makes better use of the `gulp.task('taskname', ['dependency task'], function() {})` DSL for serial task execution.

`clean` task remains the same and is listed as a standalone dependency so that
gulp.start can be used afterwards in the `build` task. not a bad tradeoff. 

The rest of the gulp tasks dependencies were listed as dependent task (array), and the
src watching that should occur. Gulp.watch used instead of the watch
module, asset building kept separate into tasks.

A build task was also added so that the initial assets can be built
before watching occurs so that there is not a partial-build and
insufficent assets to begin loading the page.
